### PR TITLE
Add missing requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 certifi==2016.2.28
 click==6.7
+configparser==3.5.0
 psycopg2==2.7.3.1
 PyYAML==3.12


### PR DESCRIPTION
When I tried to install, configparser was missing. 